### PR TITLE
changed websocket-resources lib repo to support int request ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,14 +95,13 @@
             <version>9.4-1201-jdbc41</version>
         </dependency>
         <dependency>
-            <groupId>org.whispersystems</groupId>
+            <groupId>com.github.pillarwallet</groupId>
             <artifactId>websocket-resources</artifactId>
-            <version>0.5.3</version>
+            <version>v0.5.3-1</version>
         </dependency>
         <dependency>
             <groupId>org.whispersystems</groupId>
-            <artifactId>dropwizard-simpleauth</artifactId>
-            <version>0.2.0</version>
+            <artifactId>dropwizard-si
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Previous Websocket-Resources library version was generating WebSocket request message with random Long type number which had failures while reading in React Native JavaScript protobuf library.

This version changes random Long type number to Integer.