### PR TITLE
Test failing cp command on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ jobs:
             echo "$SIGNAL_ARTIFACTORY_URL/signal-backend-$CIRCLE_BUILD_NUM.tar.gz" > pillar-signal-backend.txt
             export AWS_ACCESS_KEY_ID=$STAGING_AWS_ACCESS_KEY_ID
             export AWS_SECRET_ACCESS_KEY=$STAGING_AWS_SECRET_ACCESS_KEY
-            /root/.local/bin/aws s3 cp pillar-signal-backend.txt $QA_RELEASE_BUCKET
             /root/.local/bin/aws s3 cp pillar-signal-backend.txt $STAGING_RELEASE_BUCKET
+            /root/.local/bin/aws s3 cp pillar-signal-backend.txt $QA_RELEASE_BUCKET
       - run:
           name: Announce Deployment
           command: |
@@ -135,7 +135,7 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - fix/circleci-deploy-job
       - build-production:
           filters:
             branches:


### PR DESCRIPTION
A probably syntax error was causing the aws s3 cp command to fail, fixed now.